### PR TITLE
fixed issue in PPM 

### DIFF
--- a/uvccapture.c
+++ b/uvccapture.c
@@ -773,13 +773,13 @@ convert_yuyv_to_ppm (struct vdIn *vd, char * filename)
 #define CAP(x) ((x) < 0 ? 0 : ((x) > 255 ? 255 : (x)) )
 
       if (z++) {
-	z = 0;
-	yuyv += 4;
+	    z = 0;
+	    yuyv += 4;
       }
     }
 
+    write(fd, line_buffer, 3*vd->width);
   }
-  write(fd, line_buffer, 3*vd->width);
   free (line_buffer);
   // munmap(line_buffer, tot_len);
   close(fd);


### PR DESCRIPTION
When converting YUYV to PPM, we wrote the linebuffer to the file only at the end of the nested for loops. This resulted in a single row being written to the PPM file instead of the full file. Moving the write line into the parent for loop fixed the issue